### PR TITLE
Add BASE_URL variable

### DIFF
--- a/TestNav/TestNav.download.recipe
+++ b/TestNav/TestNav.download.recipe
@@ -10,6 +10,8 @@
     <dict>
         <key>NAME</key>
         <string>TestNav</string>
+		<key>BASE_URL</key>
+		<string>http://download.testnav.com/</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.1</string>


### PR DESCRIPTION
If you reference an input variable called “BASE_URL”, it helps to have
it defined…